### PR TITLE
added cancel action in upload notification

### DIFF
--- a/androidClient/app/build.gradle
+++ b/androidClient/app/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0-rc02'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0-rc02'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.google.android.material:material:1.0.0-rc01'
+    implementation 'com.google.android.material:material:1.0.0-rc02'
     implementation 'pub.devrel:easypermissions:1.2.0'
     implementation('com.google.api-client:google-api-client-android:1.23.0') {
         exclude group: 'org.apache.httpcomponents'
@@ -48,9 +48,9 @@ dependencies {
         exclude group: 'org.apache.httpcomponents'
     }
     implementation 'com.google.firebase:firebase-core:16.0.3'
-    implementation 'com.google.firebase:firebase-database:16.0.1'
+    implementation 'com.google.firebase:firebase-database:16.0.2'
     implementation 'com.google.firebase:firebase-auth:16.0.3'
-    implementation 'com.google.firebase:firebase-messaging:17.3.0'
+    implementation 'com.google.firebase:firebase-messaging:17.3.1'
     implementation 'com.google.firebase:firebase-config:16.0.0'
     implementation 'com.google.android.gms:play-services-auth:16.0.0'
     implementation 'com.facebook.fresco:fresco:1.10.0'
@@ -60,12 +60,12 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycle_version"
     def room_version = "2.0.0-rc01"
     implementation "androidx.room:room-runtime:$room_version"
-    implementation 'com.android.support:design:28.0.0-rc01'
+    implementation 'com.android.support:design:28.0.0-rc02'
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
     implementation "com.android.support:support-core-utils:28.1.1"
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
-    implementation 'com.android.support:support-v4:28.0.0-rc01'
-    implementation 'com.android.support:appcompat-v7:28.0.0-rc01'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation 'com.android.support:support-v4:28.0.0-rc02'
+    implementation 'com.android.support:appcompat-v7:28.0.0-rc02'
     kapt "androidx.room:room-compiler:$room_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.google.code.gson:gson:2.8.5'

--- a/androidClient/app/src/main/java/com/macbitsgoa/comrades/coursematerial/UploadUtil.java
+++ b/androidClient/app/src/main/java/com/macbitsgoa/comrades/coursematerial/UploadUtil.java
@@ -1,9 +1,7 @@
 package com.macbitsgoa.comrades.coursematerial;
 
 import android.app.Notification;
-import android.app.PendingIntent;
 import android.content.Context;
-import android.content.Intent;
 import android.util.Log;
 import android.webkit.MimeTypeMap;
 
@@ -35,24 +33,9 @@ public class UploadUtil {
     public static final String DRIVE_API_BASE_URL = "https://www.googleapis.com/drive/v3/files/";
     public static final String AUTHORIZATION_FIELD_KEY = "Authorization";
     public static final String AUTHORIZATION_FIELD_VALUE_PREFIX = "Bearer ";
-    private static final String KEY_ACCESS_TOKEN = "accessToken";
-    private static final String KEY_FILE_PATH = "filepath";
-    private static final String KEY_FILE_NAME = "filename";
     private static final String TAG = TAG_PREFIX + UploadUtil.class.getSimpleName();
 
-    public static Intent makeUploadIntent(final Context context, final String path, final String accessToken,
-                                          final String fileName) {
-        Intent intent = new Intent(context, UploadUtil.class);
-        intent.putExtra(KEY_FILE_NAME, fileName);
-        intent.putExtra(KEY_ACCESS_TOKEN, accessToken);
-        intent.putExtra(KEY_FILE_PATH, path);
-        return intent;
-    }
-
-    public static NotificationCompat.Builder sendNotification(Context context, int drawable, CharSequence message, CharSequence messageDetails) {
-        PendingIntent contentIntent = PendingIntent.getActivity(context, 0,
-                new Intent(context, UploadUtil.class), 0);
-
+    public static NotificationCompat.Builder sendNotification(Context context, int drawable, CharSequence message, CharSequence messageDetails, NotificationCompat.Action action) {
         NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context, "progress")
                 .setSmallIcon(drawable)
                 .setContentTitle(message)
@@ -60,7 +43,9 @@ public class UploadUtil {
                 .setColor(R.color.colorAccent)
                 .setAutoCancel(false)
                 .setPriority(Notification.PRIORITY_HIGH);
-        mBuilder.setContentIntent(contentIntent);
+        if (action != null) {
+            mBuilder.addAction(action);
+        }
         return mBuilder;
     }
 

--- a/androidClient/app/src/main/res/drawable/ic_close_black_24dp.xml
+++ b/androidClient/app/src/main/res/drawable/ic_close_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>


### PR DESCRIPTION
fixes #81 

Checked with two uploads :
1. upload a (possibly large) file {file A}
2. upload another file {file B}
3. cancel upload for {file A} from notif
4. :ok: {file A} upload is cancelled, {file B} uploads successfully.